### PR TITLE
Setup Dockerfile for development.

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,8 @@
+FROM node:12.13
+WORKDIR /opt/shield
+COPY package*.json ./
+COPY yarn.lock ./
+RUN yarn install
+COPY . .
+EXPOSE 5000
+CMD ["npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       POSTGRES_DB: 'shield_dev'
       POSTGRES_HOST_AUTH_METHOD: 'trust'
     volumes:
-      - shield_postgres:/data/db
+      - ./temp/postgres:/data/db
     networks:
       - backend
     ports:
@@ -46,11 +46,8 @@ services:
       POSTGRES_DB: 'shield_test'
       POSTGRES_HOST_AUTH_METHOD: 'trust'
     volumes:
-      - shield_postgres:/data/testdb
+      - ./temp/postgres-test:/data/testdb
     networks:
       - backend
     ports:
       - 4322:5432
-
-volumes:
-  shield_postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,16 @@ networks:
 
 services:
   server:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
     volumes:
       - './:/opt/shield'
       - ./node_modules:/opt/shield/node_modules
     ports:
       - 5000:5000
+    environment:
+      DB_URI: postgresql://shield_dev@postgres:5432/shield_dev
     env_file:
       - ./.env
     networks:
@@ -23,7 +27,6 @@ services:
       interval: 20s
       timeout: 5s
       retries: 12
-    command: yarn dev
   postgres:
     image: 'postgres:11.10'
     environment:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postbuild": "cpy --parents '**/*.conf' ./build/",
     "start": "node ./build/server.js",
     "dev": "nodemon --inspect=0.0.0.0:5858",
-    "start:postgres": "docker start shield_postgres-test_1",
+    "start:postgres": "docker compose up postgres-test -d",
     "test": "NODE_ENV=test node_modules/.bin/lab --sourcemaps --transform node_modules/lab-transform-typescript -l -v",
     "test:local": "yarn start:postgres && yarn test",
     "test:inspect": "yarn start:postgres && NODE_ENV=test node inspect node_modules/.bin/lab --sourcemaps --transform node_modules/lab-transform-typescript -l -v",


### PR DESCRIPTION
Creating a separate Dockerfile for development as in the current one, we run the `build` command to transpile the TS code to JS, which is not needed as we started using `ts-node` for development.