### PR TITLE
fix: policy filter in get all user api

### DIFF
--- a/test/app/user/resource.ts
+++ b/test/app/user/resource.ts
@@ -133,7 +133,7 @@ lab.experiment('User::resource', () => {
 
         const result = await Resource.list();
         Code.expect(result).to.equal(users);
-        Sandbox.assert.notCalled(getListWithFiltersStub);
+        Sandbox.assert.calledWith(getListWithFiltersStub, {});
       }
     );
 


### PR DESCRIPTION
In `Get Users` api when we apply the `role.tags` filter on the `policies` field, it is filtering the User list, not the subfield.

This happened due to the 'Where` clause is getting applied on the Users list.
So instead of doing that we can filter the casbin_rule policies at the time of aggregation.

This fix also adds support to pass multiple role tags in the query.