### PR TITLE
feat: proxy Setup

### DIFF
--- a/cmd/serve_proxy.go
+++ b/cmd/serve_proxy.go
@@ -133,7 +133,7 @@ func buildPipeline(logger log.Logger, proxy http.Handler, ruleRepo store.RuleRep
 	prefixWare := prefix.New(logger, proxy)
 	casbinAuthz := authz.New(logger, identityProxyHeader, prefixWare)
 	basicAuthn := basic_auth.New(logger, casbinAuthz)
-	matchWare := rulematch.New(logger, basicAuthn, rulematch.NewRegexMatcher(ruleRepo))
+	matchWare := rulematch.New(logger, basicAuthn, rulematch.NewRouteMatcher(ruleRepo))
 	return matchWare
 }
 

--- a/cmd/serve_proxy.go
+++ b/cmd/serve_proxy.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/odpf/shield/middleware/basic_auth"
-	"github.com/odpf/shield/middleware/casbin_authz"
+	"github.com/odpf/shield/middleware/authz"
 
 	"github.com/odpf/salt/log"
 	"github.com/odpf/shield/config"
@@ -131,7 +131,7 @@ func proxyCommand(logger log.Logger, appConfig *config.Shield) *cli.Command {
 func buildPipeline(logger log.Logger, proxy http.Handler, ruleRepo store.RuleRepository) http.Handler {
 	// Note: execution order is bottom up
 	prefixWare := prefix.New(logger, proxy)
-	casbinAuthz := casbin_authz.New(logger, prefixWare)
+	casbinAuthz := authz.New(logger, prefixWare)
 	basicAuthn := basic_auth.New(logger, casbinAuthz)
 	matchWare := rulematch.New(logger, basicAuthn, rulematch.NewRegexMatcher(ruleRepo))
 	return matchWare

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,9 @@ type Service struct {
 	// RulesPathSecret could be a env name, file path or actual value required
 	// to access RulesPath files
 	RulesPathSecret string `yaml:"ruleset_secret" mapstructure:"ruleset_secret"`
+
+	// Headers which will have user's email id
+	IdentityProxyHeader string `yaml:"identity_proxy_header" mapstructure:"identity_proxy_header"`
 }
 
 type NewRelic struct {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang-migrate/migrate/v4 v4.15.1
 	github.com/golang/protobuf v1.5.2
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/jhump/protoreflect v1.9.0
 	github.com/jmoiron/sqlx v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -633,6 +633,7 @@ github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/integration/fixtures/ruleset.grpc.yaml
+++ b/integration/fixtures/ruleset.grpc.yaml
@@ -1,31 +1,31 @@
 rules:
-  - frontend:
-      url: "/helloworld.Greeter/StreamExample"
-      methods: [ "POST" ]
-    backend:
-      url: "http://127.0.0.1:13877/"
-    middlewares:
-      - name: basic_auth
-        config:
-          users:
-            - user: user
-              password: $apr1$RfxoV6GP$.GsGgD580H5FOuUfTzKZh0
-
-  - frontend:
-      url: "/helloworld.Greeter/SayHello"
-      methods: [ "POST" ]
-    backend:
-      url: "http://127.0.0.1:13877/"
-    middlewares:
-      - name: basic_auth
-        config:
-          users:
-            - user: user
-              password: $apr1$RfxoV6GP$.GsGgD580H5FOuUfTzKZh0
-              capabilities: [ "hello:shield" ]
-          scope:
-            action: "hello:{{.name}}"
-            attributes:
-              name:
-                type: grpc_payload
-                index: 1
+  - backends:
+    - name: some_post
+      methods: ["POST"]
+      target: "http://127.0.0.1:13877/"
+      frontends:
+      - name: basic_auth_1
+        path: "/helloworld.Greeter/StreamExample"
+        method: "POST"
+        middlewares:
+        - name: basic_auth
+          config:
+            users:
+              - user: user
+                password: $apr1$RfxoV6GP$.GsGgD580H5FOuUfTzKZh0
+      - name: basic_auth_2
+        path: "/helloworld.Greeter/SayHello"
+        method: "POST"
+        middlewares:
+        - name: basic_auth
+          config:
+            users:
+              - user: user
+                password: $apr1$RfxoV6GP$.GsGgD580H5FOuUfTzKZh0
+                capabilities: [ "hello:shield" ]
+            scope:
+              action: "hello:{{.name}}"
+              attributes:
+                name:
+                  type: grpc_payload
+                  index: 1

--- a/integration/fixtures/ruleset.rest.yaml
+++ b/integration/fixtures/ruleset.rest.yaml
@@ -5,10 +5,10 @@ rules:
       target: "http://127.0.0.1:13777/"
       frontends:
       - name: some_rest_1
-        path: "basic/"
+        path: "/basic"
         method: "GET"
       - name: some_rest_2
-        path: "basic-authn/"
+        path: "/basic-authn"
         method: "GET"
         middlewares:
         - name: prefix
@@ -21,7 +21,7 @@ rules:
                 # password must be hashed using MD5, SHA1, or BCrypt(recommended) using htpasswd
                 password: $apr1$RfxoV6GP$.GsGgD580H5FOuUfTzKZh0 # md5: password
       - name: some_rest_3
-        path: "basic-authn-bcrypt/"
+        path: "/basic-authn-bcrypt"
         method: "GET"
         middlewares:
           - name: prefix
@@ -34,7 +34,7 @@ rules:
                   # password must be hashed using MD5, SHA1, or BCrypt(recommended) using htpasswd
                   password: $2y$10$F814ZwQPt8VHYIayIqeEReSeZz8dDCNX93/rKI82SqJu9I2Bn6Hau # BCrypt: password
       - name: some_rest_4
-        path: "basic-authz/"
+        path: "/basic-authz"
         method: "POST"
         middlewares:
           - name: prefix

--- a/integration/fixtures/ruleset.rest.yaml
+++ b/integration/fixtures/ruleset.rest.yaml
@@ -1,62 +1,55 @@
 rules:
-  - frontend:
-      url: "basic/"
-      methods: [ "GET" ]
-    backend:
-      url: "http://127.0.0.1:13777/"
+  - backends:
+    - name: some_post
+      methods: ["GET", "POST"]
+      target: "http://127.0.0.1:13777/"
+      frontends:
+      - name: some_rest_1
+        path: "basic/"
+        method: "GET"
+      - name: some_rest_2
+        path: "basic-authn/"
+        method: "GET"
+        middlewares:
+        - name: prefix
+          config:
+            strip: "/basic-authn"
+        - name: basic_auth
+          config:
+            users:
+              - user: user
+                # password must be hashed using MD5, SHA1, or BCrypt(recommended) using htpasswd
+                password: $apr1$RfxoV6GP$.GsGgD580H5FOuUfTzKZh0 # md5: password
+      - name: some_rest_3
+        path: "basic-authn-bcrypt/"
+        method: "GET"
+        middlewares:
+          - name: prefix
+            config:
+              strip: "/basic-authn-bcrypt"
+          - name: basic_auth
+            config:
+              users:
+                - user: user
+                  # password must be hashed using MD5, SHA1, or BCrypt(recommended) using htpasswd
+                  password: $2y$10$F814ZwQPt8VHYIayIqeEReSeZz8dDCNX93/rKI82SqJu9I2Bn6Hau # BCrypt: password
+      - name: some_rest_4
+        path: "basic-authz/"
+        method: "POST"
+        middlewares:
+          - name: prefix
+            config:
+              strip: "/basic-authz"
 
-  - frontend:
-      url: "basic-authn/"
-      methods: [ "GET" ]
-    backend:
-      url: "http://127.0.0.1:13777/"
-    middlewares:
-      - name: prefix
-        config:
-          strip: "/basic-authn"
-
-      - name: basic_auth
-        config:
-          users:
-            - user: user
-              # password must be hashed using MD5, SHA1, or BCrypt(recommended) using htpasswd
-              password: $apr1$RfxoV6GP$.GsGgD580H5FOuUfTzKZh0 # md5: password
-
-  - frontend:
-      url: "basic-authn-bcrypt/"
-      methods: [ "GET" ]
-    backend:
-      url: "http://127.0.0.1:13777/"
-    middlewares:
-      - name: prefix
-        config:
-          strip: "/basic-authn-bcrypt"
-
-      - name: basic_auth
-        config:
-          users:
-            - user: user
-              # password must be hashed using MD5, SHA1, or BCrypt(recommended) using htpasswd
-              password: $2y$10$F814ZwQPt8VHYIayIqeEReSeZz8dDCNX93/rKI82SqJu9I2Bn6Hau # BCrypt: password
-  - frontend:
-      url: "basic-authz/"
-      methods: [ "POST" ]
-    backend:
-      url: "http://127.0.0.1:13777/"
-    middlewares:
-      - name: prefix
-        config:
-          strip: "/basic-authz"
-
-      - name: basic_auth
-        config:
-          users:
-            - user: user
-              password: $apr1$RfxoV6GP$.GsGgD580H5FOuUfTzKZh0
-              capabilities: [ "ping:foo", "do:bar" ]
-          scope:
-            action: "ping:{{.project}}"
-            attributes:
-              project:
-                type: json_payload
-                key: project
+          - name: basic_auth
+            config:
+              users:
+                - user: user
+                  password: $apr1$RfxoV6GP$.GsGgD580H5FOuUfTzKZh0
+                  capabilities: [ "ping:foo", "do:bar" ]
+              scope:
+                action: "ping:{{.project}}"
+                attributes:
+                  project:
+                    type: json_payload
+                    key: project

--- a/integration/rest_test.go
+++ b/integration/rest_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/odpf/salt/log"
 	"github.com/odpf/shield/middleware/basic_auth"
-	"github.com/odpf/shield/middleware/casbin_authz"
+	"github.com/odpf/shield/middleware/authz"
 	"github.com/odpf/shield/middleware/prefix"
 	"github.com/odpf/shield/middleware/rulematch"
 	"github.com/odpf/shield/proxy"
@@ -251,7 +251,7 @@ func BenchmarkProxyOverHttp1(b *testing.B) {
 func buildPipeline(logger log.Logger, proxy http.Handler, ruleRepo store.RuleRepository) http.Handler {
 	// Note: execution order is bottom up
 	prefixWare := prefix.New(logger, proxy)
-	casbinAuthz := casbin_authz.New(logger, prefixWare)
+	casbinAuthz := authz.New(logger, prefixWare)
 	basicAuthn := basic_auth.New(logger, casbinAuthz)
 	matchWare := rulematch.New(logger, basicAuthn, rulematch.NewRegexMatcher(ruleRepo))
 	return matchWare

--- a/integration/rest_test.go
+++ b/integration/rest_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/odpf/salt/log"
-	"github.com/odpf/shield/middleware/basic_auth"
 	"github.com/odpf/shield/middleware/authz"
+	"github.com/odpf/shield/middleware/basic_auth"
 	"github.com/odpf/shield/middleware/prefix"
 	"github.com/odpf/shield/middleware/rulematch"
 	"github.com/odpf/shield/proxy"
@@ -251,7 +251,7 @@ func BenchmarkProxyOverHttp1(b *testing.B) {
 func buildPipeline(logger log.Logger, proxy http.Handler, ruleRepo store.RuleRepository) http.Handler {
 	// Note: execution order is bottom up
 	prefixWare := prefix.New(logger, proxy)
-	casbinAuthz := authz.New(logger, prefixWare)
+	casbinAuthz := authz.New(logger, "", prefixWare)
 	basicAuthn := basic_auth.New(logger, casbinAuthz)
 	matchWare := rulematch.New(logger, basicAuthn, rulematch.NewRegexMatcher(ruleRepo))
 	return matchWare

--- a/middleware/authz/authz.go
+++ b/middleware/authz/authz.go
@@ -53,7 +53,6 @@ func (c *Authz) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	permissionAttributes := map[string]string{}
 
-
 	// TODO: check if action matchers user capabilities
 	// config.Action
 

--- a/middleware/authz/authz.go
+++ b/middleware/authz/authz.go
@@ -131,7 +131,13 @@ func (c *Authz) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	paramMap, _ := middleware.ExtractPathParams(req)
+	paramMap, mapExists := middleware.ExtractPathParams(req)
+	if !mapExists {
+		c.log.Error("middleware: path param map doesn't exist")
+		c.notAllowed(rw)
+		return
+	}
+
 	for key, value := range paramMap {
 		permissionAttributes[key] = value
 	}

--- a/middleware/authz/authz.go
+++ b/middleware/authz/authz.go
@@ -53,13 +53,9 @@ func (c *Authz) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	permissionAttributes := map[string]string{}
 
-	// TODO: check if action matchers user capabilities
-	// config.Action
-
 	permissionAttributes["user"] = req.Header.Get(c.identityProxyHeader)
 
 	for res, attr := range config.Attributes {
-		// TODO: do something about this
 		_ = res
 
 		switch attr.Type {
@@ -163,6 +159,8 @@ func (c *Authz) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 	}
+
+	// use permissionAttributes &config.Action here
 
 	c.next.ServeHTTP(rw, req)
 }

--- a/middleware/grpc_payload.go
+++ b/middleware/grpc_payload.go
@@ -131,9 +131,9 @@ func buildPayloadGenericProto() (*desc.MessageDescriptor, error) {
 		return genericProtoCache, nil
 	}
 
-	builderMsg := builder.NewMessage("optimus")
+	builderMsg := builder.NewMessage("message")
 	for i := 1; i < 100; i++ {
-		builderMsg.AddField(builder.NewField(fmt.Sprintf("optimus_field_%d", i),
+		builderMsg.AddField(builder.NewField(fmt.Sprintf("field_%d", i),
 			builder.FieldTypeScalar(descriptor.FieldDescriptorProto_TYPE_STRING)).SetNumber(int32(i)))
 	}
 	desc, err := builderMsg.Build()

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -35,14 +35,17 @@ const (
 	AttributeTypeHeader      AttributeType = "header"
 	AttributeTypeJSONPayload AttributeType = "json_payload"
 	AttributeTypeGRPCPayload AttributeType = "grpc_payload"
+	AttributeTypePathParam   AttributeType = "path_param"
 )
 
 type AttributeType string
 
 type Attribute struct {
-	Key   string        `yaml:"key" mapstructure:"key"`
-	Type  AttributeType `yaml:"type" mapstructure:"type"`
-	Index int           `yaml:"index" mapstructure:"index"` // proto index
+	Key    string        `yaml:"key" mapstructure:"key"`
+	Type   AttributeType `yaml:"type" mapstructure:"type"`
+	Index  int           `yaml:"index" mapstructure:"index"` // proto index
+	Path   string        `yaml:"path" mapstructure:"path"`
+	Params []string      `yaml:"params" mapstructure:"params"`
 }
 
 func Elapsed(what string) func() {

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	ctxRuleKey = "middleware_rule"
+	ctxRuleKey       = "middleware_rule"
+	ctxPathParamsKey = "path_params"
 )
 
 func EnrichRule(r *http.Request, rule *structs.Rule) {
@@ -28,6 +29,18 @@ func ExtractMiddleware(r *http.Request, name string) (structs.MiddlewareSpec, bo
 		return structs.MiddlewareSpec{}, false
 	}
 	return rl.Middlewares.Get(name)
+}
+
+func EnrichPathParams(r *http.Request, params map[string]string) {
+	*r = *r.WithContext(context.WithValue(r.Context(), ctxPathParamsKey, params))
+}
+
+func ExtractPathParams(r *http.Request) (map[string]string, bool) {
+	params, ok := r.Context().Value(ctxPathParamsKey).(map[string]string)
+	if !ok {
+		return nil, false
+	}
+	return params, true
 }
 
 const (

--- a/middleware/rulematch/regex_matcher.go
+++ b/middleware/rulematch/regex_matcher.go
@@ -20,14 +20,7 @@ func (m RegexMatcher) Match(ctx context.Context, reqMethod string, reqURL *url.U
 
 	for _, set := range ruleset {
 		for _, rule := range set.Rules {
-			var isMethodMatch bool
-			for _, ruleMethod := range rule.Frontend.Methods {
-				if reqMethod == ruleMethod {
-					isMethodMatch = true
-					break
-				}
-			}
-			if !isMethodMatch {
+			if reqMethod != rule.Frontend.Method {
 				continue
 			}
 

--- a/middleware/rulematch/route_matcher.go
+++ b/middleware/rulematch/route_matcher.go
@@ -1,0 +1,42 @@
+package rulematch
+
+import (
+	"net/http"
+
+	"github.com/odpf/shield/middleware"
+	"github.com/odpf/shield/store"
+	"github.com/odpf/shield/structs"
+
+	"github.com/gorilla/mux"
+)
+
+type RouteMatcher struct {
+	ruleRepo store.RuleRepository
+}
+
+func (r RouteMatcher) Match(req *http.Request) (*structs.Rule, error) {
+	ruleset, err := r.ruleRepo.GetAll(req.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, set := range ruleset {
+		for _, rule := range set.Rules {
+			router := mux.NewRouter()
+			router.StrictSlash(true)
+			route := router.NewRoute().Path(rule.Frontend.URL).Methods(rule.Frontend.Method)
+			routeMatcher := mux.RouteMatch{}
+			if route.Match(req, &routeMatcher) {
+				middleware.EnrichPathParams(req, routeMatcher.Vars)
+				return &rule, nil
+			}
+		}
+	}
+	return nil, ErrUnknownRule
+}
+
+func NewRouteMatcher(ruleRepo store.RuleRepository) *RouteMatcher {
+	return &RouteMatcher{
+		ruleRepo: ruleRepo,
+	}
+}

--- a/middleware/rulematch/rulematch.go
+++ b/middleware/rulematch/rulematch.go
@@ -36,7 +36,7 @@ func (m Ware) Info() *structs.MiddlewareInfo {
 
 func (m *Ware) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// find matched rule
-	matchedRule, err := m.ruleMatcher.Match(req.Context(), req.Method, req.URL)
+	matchedRule, err := m.ruleMatcher.Match(req)
 	if err != nil {
 		m.log.Info("middleware: failed to match rule", "path", req.URL.String(), "err", err)
 		rw.WriteHeader(http.StatusBadRequest)

--- a/rules/sample.rest.yaml
+++ b/rules/sample.rest.yaml
@@ -11,8 +11,8 @@ rules:
                 config:
                   action: abc
                   attributes:
-                    project:
-                      key: id.project
+                    group:
+                      key: id.group
                       type: json_payload
           - name: some_rest_1
             path: "/basic1/{project:(?:.*\\/.*)}"

--- a/rules/sample.rest.yaml
+++ b/rules/sample.rest.yaml
@@ -1,56 +1,76 @@
-basic_auth_user_db: &USER_DB
-  - user: user
-    # password must be hashed using MD5, SHA1, or BCrypt(recommended) using htpasswd
-    # Note: hashing via bcrypt do add additional ~50ms to each request
-    # password: $apr1$RfxoV6GP$.GsGgD580H5FOuUfTzKZh0 # password via md5
-    password: $2y$10$F814ZwQPt8VHYIayIqeEReSeZz8dDCNX93/rKI82SqJu9I2Bn6Hau # password via bcrypt
-    capabilities: [ "ping:foo", "do:bar" ]
 rules:
-  - frontend:
-      url: "sample/"
-      methods: ["GET", "POST"]
-    backend:
-      url: "http://localhost:8080/"
-    middlewares:
-      - name: prefix
-        config:
-          # should be prefixed with a slash almost always
-          strip: "/sample"
+  - backends:
+      - name: some_post
+        target: "http://127.0.0.1:3030/"
+        frontends:
+          - name: some_rest_1
+            path: "/basic1/{project:(?:.*\\/.*)}"
+            method: "POST"
+            middlewares:
+              - name: authz
+                config:
+                  action: abc
+                  attributes:
+                    project:
+                      key: id.project
+                      type: json_payload
+          - name: some_rest_1
+            path: "/basic1/{project:(?:.*\\/.*)}"
+            method: "GET"
+            middlewares:
+              - name: authz
+                config:
+                  action: abc
+                  attributes:
+                    project:
+                      key: project
+                      type: header
+          - name: some_rest_get_1
+            path: "/basic"
+            method: "GET"
+          - name: some_rest_2
+            path: "/basic-authn"
+            method: "GET"
+            middlewares:
+              - name: prefix
+                config:
+                  strip: "/basic-authn"
+              - name: basic_auth
+                config:
+                  users:
+                    - user: user
+                      # password must be hashed using MD5, SHA1, or BCrypt(recommended) using htpasswd
+                      password: $apr1$RfxoV6GP$.GsGgD580H5FOuUfTzKZh0 # md5: password
+          - name: some_rest_3
+            path: "/basic-authn-bcrypt"
+            method: "GET"
+            middlewares:
+              - name: prefix
+                config:
+                  strip: "/basic-authn-bcrypt"
+              - name: basic_auth
+                config:
+                  users:
+                    - user: user
+                      # password must be hashed using MD5, SHA1, or BCrypt(recommended) using htpasswd
+                      password: $2y$10$F814ZwQPt8VHYIayIqeEReSeZz8dDCNX93/rKI82SqJu9I2Bn6Hau # BCrypt: password
+          - name: some_rest_4
+            path: "/basic-authz"
+            method: "POST"
+            middlewares:
+              - name: prefix
+                config:
+                  strip: "/basic-authz"
 
-      # not supported at the moment
-      - name: request_headers
-        config:
-          allow: ["foo", "bar"]
-
-  - frontend:
-      url: "sample-auth/"
-      methods: ["GET", "POST"]
-    backend:
-      url: "http://localhost:8080/"
-    middlewares:
-      - name: prefix
-        config:
-          strip: "/sample-auth"
-
-      - name: basic_auth
-        config:
-          users: *USER_DB
-  - frontend:
-      url: "sample-authz/"
-      methods: ["POST"]
-    backend:
-      url: "http://localhost:8080/"
-    middlewares:
-      - name: prefix
-        config:
-          strip: "/sample-authz"
-
-      - name: basic_auth
-        config:
-          users: *USER_DB
-          scope:
-            action: "ping:{{.project}}"
-            attributes:
-              project:
-                type: json_payload
-                key: project
+              - name: basic_auth
+                config:
+                  users:
+                    - user: user
+                      password: $apr1$RfxoV6GP$.GsGgD580H5FOuUfTzKZh0
+                      capabilities: [ "ping:foo", "do:bar" ]
+                  scope:
+                    action: "ping:{{.project}}"
+                    attributes:
+                      project:
+                        type: json_payload
+                        key: project

--- a/store/blob/rule_repository.go
+++ b/store/blob/rule_repository.go
@@ -2,6 +2,7 @@ package blob
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"regexp"
 	"strings"
@@ -95,6 +96,7 @@ func (repo *RuleRepository) refresh(ctx context.Context) error {
 
 		var s Ruleset
 		if err := yaml.Unmarshal(fileBytes, &s); err != nil {
+			fmt.Println(err)
 			return errors.Wrap(err, "yaml.Unmarshal: "+obj.Key)
 		}
 		if len(s.Rules) == 0 {

--- a/store/blob/rule_repository.go
+++ b/store/blob/rule_repository.go
@@ -101,7 +101,7 @@ func (repo *RuleRepository) refresh(ctx context.Context) error {
 			continue
 		}
 
-		// transforming yaml parse ruleset to clearer iterable ruleset
+		// transforming yaml parse ruleset to clean iterable ruleset in middlewares
 		targetRuleSet := structs.Ruleset{}
 		for _, rule := range s.Rules {
 			for _, backend := range rule.Backends {
@@ -122,7 +122,6 @@ func (repo *RuleRepository) refresh(ctx context.Context) error {
 						Backend:     structs.Backend{URL: backend.Target},
 						Middlewares: middlewares,
 					})
-
 				}
 			}
 		}

--- a/store/blob/rule_repository.go
+++ b/store/blob/rule_repository.go
@@ -19,6 +19,33 @@ import (
 	"gocloud.dev/blob"
 )
 
+type Ruleset struct {
+	Rules []Rule `yaml:"rules"`
+}
+
+type Rule struct {
+	Backends []Backend `yaml:"backends"`
+}
+
+type Backend struct {
+	Name      string     `yaml:"name"`
+	Target    string     `yaml:"target"`
+	Methods   []string   `yaml:"methods"`
+	Frontends []Frontend `yaml:"frontends"`
+}
+
+type Frontend struct {
+	Action      string       `yaml:"action"`
+	Path        string       `yaml:"path"`
+	Method      string       `yaml:"method"`
+	Middlewares []Middleware `yaml:"middlewares"`
+}
+
+type Middleware struct {
+	Name   string                 `yaml:"name"`
+	Config map[string]interface{} `yaml:"config"`
+}
+
 type RuleRepository struct {
 	log log.Logger
 	mu  *sync.Mutex
@@ -66,7 +93,7 @@ func (repo *RuleRepository) refresh(ctx context.Context) error {
 			return errors.Wrap(err, "bucket.ReadAll: "+obj.Key)
 		}
 
-		var s structs.Ruleset
+		var s Ruleset
 		if err := yaml.Unmarshal(fileBytes, &s); err != nil {
 			return errors.Wrap(err, "yaml.Unmarshal: "+obj.Key)
 		}
@@ -74,11 +101,37 @@ func (repo *RuleRepository) refresh(ctx context.Context) error {
 			continue
 		}
 
+		// transforming yaml parse ruleset to clearer iterable ruleset
+		targetRuleSet := structs.Ruleset{}
+		for _, rule := range s.Rules {
+			for _, backend := range rule.Backends {
+				for _, frontend := range backend.Frontends {
+					middlewares := structs.MiddlewareSpecs{}
+					for _, middleware := range frontend.Middlewares {
+						middlewares = append(middlewares, structs.MiddlewareSpec{
+							Name:   middleware.Name,
+							Config: middleware.Config,
+						})
+					}
+
+					targetRuleSet.Rules = append(targetRuleSet.Rules, structs.Rule{
+						Frontend: structs.Frontend{
+							URL:    frontend.Path,
+							Method: frontend.Method,
+						},
+						Backend:     structs.Backend{URL: backend.Target},
+						Middlewares: middlewares,
+					})
+
+				}
+			}
+		}
+
 		// parse all urls at this time only to avoid doing it usage
 		var rxParsingSuccess = true
-		for ruleIdx, rule := range s.Rules {
+		for ruleIdx, rule := range targetRuleSet.Rules {
 			// TODO: only compile between delimiter, maybe angular brackets
-			s.Rules[ruleIdx].Frontend.URLRx, err = regexp.Compile(rule.Frontend.URL)
+			targetRuleSet.Rules[ruleIdx].Frontend.URLRx, err = regexp.Compile(rule.Frontend.URL)
 			if err != nil {
 				rxParsingSuccess = false
 				repo.log.Error("failed to parse rule frontend as a valid regular expression",
@@ -87,7 +140,7 @@ func (repo *RuleRepository) refresh(ctx context.Context) error {
 		}
 
 		if rxParsingSuccess {
-			ruleset = append(ruleset, s)
+			ruleset = append(ruleset, targetRuleSet)
 		} else {
 			repo.log.Warn("skipping rule set due to parsing errors", "content", string(fileBytes))
 		}

--- a/structs/rule.go
+++ b/structs/rule.go
@@ -1,8 +1,7 @@
 package structs
 
 import (
-	"context"
-	"net/url"
+	"net/http"
 	"regexp"
 )
 
@@ -44,5 +43,5 @@ type Backend struct {
 }
 
 type RuleMatcher interface {
-	Match(ctx context.Context, reqMethod string, reqURL *url.URL) (*Rule, error)
+	Match(req *http.Request) (*Rule, error)
 }

--- a/structs/rule.go
+++ b/structs/rule.go
@@ -36,7 +36,7 @@ type Frontend struct {
 	URL   string         `yaml:"url"`
 	URLRx *regexp.Regexp `yaml:"-"`
 
-	Methods []string `yaml:"methods"`
+	Method string `yaml:"method"`
 }
 
 type Backend struct {


### PR DESCRIPTION
1.Issue where we cannot use proxy for http & http2. This just works for h2c & grpc.
Solving this by using different RoundTrippers for grpc and others
Tested this for
  - [x]  http using echo server
  - [x]  http2 using postb.in
  - [x]  grpc using integration/grpc_test.go#L200
  - [x]  h2c using integration/rest_test.go#L260


<br>
2. Extract required attributes from request

- [x] Extract Identity ID from header
- [x] Extract Permission Attributes like project, team, org from
  - [x] Path Param
  - [x] Query Param
  - [x] Payload
  - [x] Headers

<br>
3. Use gorilla.mux instead of regex to match rules
<br>
<br>
4. Change rule yaml format

```yaml
rules:
  - backends:
      - name: firehose
        target: "http://localhost:3030"
        frontends:
          - action: READ_FIREHOSE
            path: "/v2/firehose"
            method: "POST"
            middlewares:
              - name: authz
                config:
                  attributes:
                    project:
                      type: json_payload
                      key: id.project
          - name: test2
            path: "/v2/firehose"
            method: "GET"
            middlewares:
              - name: authz
                config:
                  attributes:
                    project:
                      type: json_payload
                      key: id.project
      - name: dagger
        target: "http://localhost:3030/new"
        frontends:
          - action: READ_FIREHOSE
            path: "/v2/dagger"
            method: "POST"
            middlewares:
              - name: authz
                config:
                  attributes:
                    project:
                      type: json_payload
                      key: id.project
          - action: test2
            path: "/v2/dagger"
            method: "GET"
            middlewares:
              - name: authz
                config:
                  attributes:
                    project:
                      type: json_payload
                      key: id.project
```