### PR TITLE
fix: escape from hook when resp is >= 400 and disable decoding

### DIFF
--- a/hook/authz/authz.go
+++ b/hook/authz/authz.go
@@ -50,7 +50,7 @@ func (a Authz) Info() hook.Info {
 }
 
 func (a Authz) ServeHook(res *http.Response, err error) (*http.Response, error) {
-	if err != nil {
+	if err != nil || res.StatusCode >= 400 {
 		return a.escape.ServeHook(res, err)
 	}
 


### PR DESCRIPTION
- [x] Decompression / Decoding of response body on Hooks
- [x] Escape Hooks when response is not 2xx & 3xx