### PR TITLE
use a format to combine resource type in namespaces

### DIFF
--- a/resources_config/resources.yaml
+++ b/resources_config/resources.yaml
@@ -1,21 +1,16 @@
-resources:
+backends:
   - name: guardian
-    actions:
-      read:
-        - owner
-      delete:
-        - owner
-  - name: dagger
-    actions:
-      all_actions:
-        - owner
-      read:
-        - team.team_member
-      delete:
-        - team.team_member
-  - name: firehose
-    actions:
-      read:
-        - team.team_member
-      delete:
-        - team.team_member
+    resource_types:
+      - name: "appeal"
+        actions:
+          read:
+            - owner
+          delete:
+            - owner
+      - name: "provider"
+        actions:
+          read:
+            - owner
+            - "organization.organization_admin"
+          write:
+            - owner


### PR DESCRIPTION
Using a new format to define namespaces, which will be combined with resource_type


```yaml
backends:
  - name: guardian
    resource_types:
      - name: "appeal"
        actions:
          read:
            - owner
          delete:
            - owner
      - name: "provider"
        actions:
          read:
            - owner
            - "organization.organization_admin"
          write:
            - owner

```