### PR TITLE
feat: change error msg for unauthorized actions

### DIFF
--- a/api/handler/v1beta1/group.go
+++ b/api/handler/v1beta1/group.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/odpf/shield/internal/group"
 	"github.com/odpf/shield/model"
+	shieldError "github.com/odpf/shield/utils/errors"
 
 	shieldv1beta1 "github.com/odpf/shield/proto/v1beta1"
 
@@ -165,6 +166,8 @@ func (v Dep) AddGroupUser(ctx context.Context, request *shieldv1beta1.AddGroupUs
 		switch {
 		case errors.Is(err, group.GroupDoesntExist):
 			return nil, status.Errorf(codes.NotFound, "group to be updated not found")
+		case errors.Is(err, shieldError.Unauthorzied):
+			return nil, grpcPermissionDenied
 		default:
 			return nil, grpcInternalServerError
 		}
@@ -195,6 +198,8 @@ func (v Dep) RemoveGroupUser(ctx context.Context, request *shieldv1beta1.RemoveG
 		switch {
 		case errors.Is(err, group.GroupDoesntExist):
 			return nil, status.Errorf(codes.NotFound, "group to be updated not found")
+		case errors.Is(err, shieldError.Unauthorzied):
+			return nil, grpcPermissionDenied
 		default:
 			return nil, grpcInternalServerError
 		}

--- a/api/handler/v1beta1/org.go
+++ b/api/handler/v1beta1/org.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/odpf/shield/internal/org"
 	"github.com/odpf/shield/model"
+	shieldError "github.com/odpf/shield/utils/errors"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -169,6 +170,8 @@ func (v Dep) AddOrganizationAdmin(ctx context.Context, request *shieldv1beta1.Ad
 		switch {
 		case errors.Is(err, org.OrgDoesntExist):
 			return nil, status.Errorf(codes.NotFound, "org to be updated not found")
+		case errors.Is(err, shieldError.Unauthorzied):
+			return nil, grpcPermissionDenied
 		default:
 			return nil, grpcInternalServerError
 		}
@@ -225,6 +228,8 @@ func (v Dep) RemoveOrganizationAdmin(ctx context.Context, request *shieldv1beta1
 		switch {
 		case errors.Is(err, org.OrgDoesntExist):
 			return nil, status.Errorf(codes.NotFound, "org to be updated not found")
+		case errors.Is(err, shieldError.Unauthorzied):
+			return nil, grpcPermissionDenied
 		default:
 			return nil, grpcInternalServerError
 		}

--- a/api/handler/v1beta1/util.go
+++ b/api/handler/v1beta1/util.go
@@ -14,6 +14,7 @@ import (
 var (
 	grpcInternalServerError = status.Errorf(codes.Internal, internalServerError.Error())
 	grpcBadBodyError        = status.Error(codes.InvalidArgument, badRequestError.Error())
+	grpcPermissionDenied    = status.Error(codes.PermissionDenied, permissionDeniedError.Error())
 )
 
 func mapOfStringValues(m map[string]interface{}) (map[string]string, error) {

--- a/api/handler/v1beta1/v1.go
+++ b/api/handler/v1beta1/v1.go
@@ -26,8 +26,9 @@ type Dep struct {
 }
 
 var (
-	internalServerError = errors.New("internal server error")
-	badRequestError     = errors.New("invalid syntax in body")
+	internalServerError   = errors.New("internal server error")
+	badRequestError       = errors.New("invalid syntax in body")
+	permissionDeniedError = errors.New("permission denied")
 )
 
 func RegisterV1(ctx context.Context, s *server.MuxServer, gw *server.GRPCGateway, dep Dep) {


### PR DESCRIPTION
Currently, shield returns an `internal server error` response when an unauthorized user tries to make an action. I am proposing to change the response to
```
{
    "code": 7,
    "message": "permission denied",
    "details": []
}
```

`PermissionDenied Code = 7`

Wdyt @rsbh @krtkvrm ? 