### PR TITLE
feat: upsert the relationship from authz hook

### DIFF
--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -18,6 +18,7 @@ type Permission interface {
 	AddRelation(ctx context.Context, relation model.Relation) error
 	DeleteRelation(ctx context.Context, relation model.Relation) error
 	CheckRelation(ctx context.Context, relation model.Relation, action model.Action) (bool, error)
+	DeleteSubjectRelations(ctx context.Context, resource model.Resource) error
 }
 
 type Authz struct {

--- a/internal/authz/spicedb/spicedb.go
+++ b/internal/authz/spicedb/spicedb.go
@@ -133,3 +133,20 @@ func (p Permission) DeleteRelation(ctx context.Context, relation model.Relation)
 
 	return nil
 }
+
+func (p Permission) DeleteSubjectRelations(ctx context.Context, resource model.Resource) error {
+	request := &pb.DeleteRelationshipsRequest{
+		RelationshipFilter: &pb.RelationshipFilter{
+			ResourceType:       resource.NamespaceId,
+			OptionalResourceId: resource.Idxa,
+		},
+	}
+
+	_, err := p.client.DeleteRelationships(ctx, request)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/permission/relation.go
+++ b/internal/permission/relation.go
@@ -44,6 +44,7 @@ type Permissions interface {
 	FetchCurrentUser(ctx context.Context) (model.User, error)
 	CheckPermission(ctx context.Context, user model.User, resource model.Resource, action model.Action) (bool, error)
 	RemoveRelation(ctx context.Context, rel model.Relation) error
+	DeleteSubjectRelations(ctx context.Context, resource model.Resource) error
 }
 
 func (s Service) addRelation(ctx context.Context, rel model.Relation) error {
@@ -57,6 +58,10 @@ func (s Service) addRelation(ctx context.Context, rel model.Relation) error {
 		return err
 	}
 	return nil
+}
+
+func (s Service) DeleteSubjectRelations(ctx context.Context, resource model.Resource) error {
+	return s.Authz.Permission.DeleteSubjectRelations(ctx, resource)
 }
 
 func (s Service) RemoveRelation(ctx context.Context, rel model.Relation) error {

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -59,6 +59,10 @@ func (s Service) Create(ctx context.Context, resource model.Resource) (model.Res
 		return model.Resource{}, err
 	}
 
+	if err = s.Permissions.DeleteSubjectRelations(ctx, newResource); err != nil {
+		return model.Resource{}, err
+	}
+
 	if newResource.GroupId != "" {
 		err = s.Permissions.AddTeamToResource(ctx, model.Group{Id: resource.GroupId}, newResource)
 		if err != nil {

--- a/resources_config/resources.yaml
+++ b/resources_config/resources.yaml
@@ -7,3 +7,9 @@ backends:
 #            - team.experimenter
 #            - owner
 #            - two
+  - name: odin
+    resource_types:
+      - name: "firehose"
+        actions:
+          manage:
+            - team.firehose_manager

--- a/store/postgres/migrations/20220523150122_create_constraint_resource_urn.down.sql
+++ b/store/postgres/migrations/20220523150122_create_constraint_resource_urn.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE resources
+DROP CONSTRAINT resources_urn_unique;

--- a/store/postgres/migrations/20220523150122_create_constraint_resource_urn.up.sql
+++ b/store/postgres/migrations/20220523150122_create_constraint_resource_urn.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE resources
+ADD CONSTRAINT resources_urn_unique UNIQUE (urn);

--- a/store/postgres/resource.go
+++ b/store/postgres/resource.go
@@ -52,6 +52,9 @@ const (
 		    $6,
 		    $7
 		)
+		ON CONFLICT ON CONSTRAINT resources_urn_unique 
+		DO
+		    UPDATE SET name=$2, project_id=$3, group_id=$4, org_id=$5, namespace_id=$6,user_id=$7
 		RETURNING id, urn, name, project_id, group_id, org_id, namespace_id, user_id, created_at, updated_at;`
 	getResourcesQueryByURN = `
 		SELECT


### PR DESCRIPTION
Changing the behaviour of creating resource from hooks from `insert` to `upsert`. This can support both POST and PUT