### PR TITLE
fix: Handle shield unauthorized error

### DIFF
--- a/api/handler/v1beta1/group.go
+++ b/api/handler/v1beta1/group.go
@@ -286,6 +286,8 @@ func (v Dep) AddGroupAdmin(ctx context.Context, request *shieldv1beta1.AddGroupA
 		switch {
 		case errors.Is(err, group.GroupDoesntExist):
 			return nil, status.Errorf(codes.NotFound, "group to be updated not found")
+		case errors.Is(err, shieldError.Unauthorzied):
+			return nil, grpcPermissionDenied
 		default:
 			return nil, grpcInternalServerError
 		}
@@ -316,6 +318,8 @@ func (v Dep) RemoveGroupAdmin(ctx context.Context, request *shieldv1beta1.Remove
 		switch {
 		case errors.Is(err, group.GroupDoesntExist):
 			return nil, status.Errorf(codes.NotFound, "group to be updated not found")
+		case errors.Is(err, shieldError.Unauthorzied):
+			return nil, grpcPermissionDenied
 		default:
 			return nil, grpcInternalServerError
 		}


### PR DESCRIPTION
As a non-admin User, tried to remove/add another user from a group, as expected Shield throws here an unauthorized error. But the API handler layer does not capture the error and throws grcpInternalError and its result to 500 HTTP error code in response.