### PR TITLE
fix: dockerfile dev file

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,6 +11,13 @@ COPY . .
 
 RUN make build
 
-FROM alpine:3.15
-COPY --from=builder /go/src/app/shield /usr/local/bin/
-ENTRYPOINT [ "shield" ]
+FROM alpine:3.16
+COPY --from=builder /go/src/app/shield /usr/bin/
+RUN apk update
+RUN apk add ca-certificates
+
+# glibc compatibility library, since go binaries 
+# don't work well with musl libc that alpine uses
+RUN apk add libc6-compat
+
+CMD ["shield", "serve"]


### PR DESCRIPTION
We use Dockerfile.dev to build a tag dev. Our current Dockerfile.dev copied shield to /usr/local/bin/shield but the Dockerfile is copying shield to usr/bin/shield.

We expect the same path between Dockerfile and Dockerfile.dev. We need to update Dockerfile.dev so shield is copied to /usr/bin/shield.

**Changes**
- Copy shield to `usr/bin`
- Add `glibc` for compatibility purpose
