### PR TITLE
feat: prevent proxy context cancelled

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,9 +78,9 @@ services:
   spicedb:
     image: quay.io/authzed/spicedb:v1.0.0
     ports:
-      - "8081:8080"
-      - "50052:50051"
-      - "50054:50053"
+      - "8080:8080"
+      - "50051:50051"
+      - "50053:50053"
     command:
       spicedb serve --grpc-preshared-key "shield" --grpc-no-tls --datastore-engine postgres
       --datastore-conn-uri postgres://spicedb:@pg2:5432/spicedb?sslmode=disable

--- a/internal/proxy/context.go
+++ b/internal/proxy/context.go
@@ -1,0 +1,30 @@
+package proxy
+
+import (
+	"context"
+	"time"
+)
+
+type Context struct {
+	ctx context.Context
+}
+
+func (c Context) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (c Context) Done() <-chan struct{} {
+	return nil
+}
+
+func (c Context) Err() error {
+	return nil
+}
+
+func (c Context) Value(key interface{}) interface{} {
+	return c.ctx.Value(key)
+}
+
+func WithoutCancel(ctx context.Context) context.Context {
+	return Context{ctx: ctx}
+}

--- a/internal/proxy/roundtripper.go
+++ b/internal/proxy/roundtripper.go
@@ -32,7 +32,10 @@ func (t *h2cTransportWrapper) RoundTrip(req *http.Request) (*http.Response, erro
 	// we need to apply errors if it failed in Director
 	if err, ok := req.Context().Value(ctxRequestErrorKey).(error); ok {
 		return nil, err
+	} else if req.Context().Err() != nil {
+		return nil, req.Context().Err()
 	}
+
 	t.log.Debug("proxy request", "host", req.URL.Host, "path", req.URL.Path,
 		"scheme", req.URL.Scheme, "protocol", req.Proto)
 

--- a/internal/proxy/roundtripper.go
+++ b/internal/proxy/roundtripper.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"context"
 	"crypto/tls"
 	"net"
 	"net/http"
@@ -27,30 +26,6 @@ type h2cTransportWrapper struct {
 
 	log  log.Logger
 	hook hook.Service
-}
-
-type Context struct {
-	ctx context.Context
-}
-
-func (c Context) Deadline() (time.Time, bool) {
-	return time.Time{}, false
-}
-
-func (c Context) Done() <-chan struct{} {
-	return nil
-}
-
-func (c Context) Err() error {
-	return nil
-}
-
-func (c Context) Value(key interface{}) interface{} {
-	return c.ctx.Value(key)
-}
-
-func WithoutCancel(ctx context.Context) context.Context {
-	return Context{ctx: ctx}
 }
 
 func (t *h2cTransportWrapper) RoundTrip(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
Expectation
- [x] request cancellation or interruption from client side should not stop processing on shield side