### PR TITLE
fix: bug in group, role, and policy

### DIFF
--- a/core/role/service.go
+++ b/core/role/service.go
@@ -15,7 +15,7 @@ func NewService(repository Repository) *Service {
 func (s Service) Create(ctx context.Context, toCreate Role) (Role, error) {
 	roleID, err := s.repository.Create(ctx, toCreate)
 	if err != nil {
-		return Role{}, nil
+		return Role{}, err
 	}
 	return s.repository.Get(ctx, roleID)
 }
@@ -31,7 +31,7 @@ func (s Service) List(ctx context.Context) ([]Role, error) {
 func (s Service) Update(ctx context.Context, toUpdate Role) (Role, error) {
 	roleID, err := s.repository.Update(ctx, toUpdate)
 	if err != nil {
-		return Role{}, nil
+		return Role{}, err
 	}
 	return s.repository.Get(ctx, roleID)
 }

--- a/internal/api/v1beta1/group.go
+++ b/internal/api/v1beta1/group.go
@@ -87,7 +87,6 @@ func (h Handler) CreateGroup(ctx context.Context, request *shieldv1beta1.CreateG
 	}
 
 	newGroup, err := h.groupService.Create(ctx, grp)
-
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, grpcInternalServerError
@@ -228,18 +227,20 @@ func (h Handler) UpdateGroup(ctx context.Context, request *shieldv1beta1.UpdateG
 	var updatedGroup group.Group
 	if uuid.IsValid(request.GetId()) {
 		updatedGroup, err = h.groupService.Update(ctx, group.Group{
-			ID:           request.GetId(),
-			Name:         request.GetBody().GetName(),
-			Slug:         request.GetBody().GetSlug(),
-			Organization: organization.Organization{ID: request.GetBody().GetOrgId()},
-			Metadata:     metaDataMap,
+			ID:             request.GetId(),
+			Name:           request.GetBody().GetName(),
+			Slug:           request.GetBody().GetSlug(),
+			Organization:   organization.Organization{ID: request.GetBody().GetOrgId()},
+			OrganizationID: request.GetBody().GetOrgId(),
+			Metadata:       metaDataMap,
 		})
 	} else {
 		updatedGroup, err = h.groupService.Update(ctx, group.Group{
-			Name:         request.GetBody().GetName(),
-			Slug:         request.GetId(),
-			Organization: organization.Organization{ID: request.GetBody().GetOrgId()},
-			Metadata:     metaDataMap,
+			Name:           request.GetBody().GetName(),
+			Slug:           request.GetId(),
+			Organization:   organization.Organization{ID: request.GetBody().GetOrgId()},
+			OrganizationID: request.GetBody().GetOrgId(),
+			Metadata:       metaDataMap,
 		})
 	}
 	if err != nil {

--- a/internal/api/v1beta1/namespace.go
+++ b/internal/api/v1beta1/namespace.go
@@ -100,10 +100,9 @@ func (h Handler) UpdateNamespace(ctx context.Context, request *shieldv1beta1.Upd
 	logger := grpczap.Extract(ctx)
 
 	updatedNS, err := h.namespaceService.Update(ctx, namespace.Namespace{
-		ID:   request.GetBody().GetId(),
-		Name: request.GetBody().GetName(),
+		ID:   request.GetId(),
+		Name: request.GetBody().Name,
 	})
-
 	if err != nil {
 		logger.Error(err.Error())
 		switch {

--- a/internal/api/v1beta1/role.go
+++ b/internal/api/v1beta1/role.go
@@ -116,10 +116,10 @@ func (h Handler) UpdateRole(ctx context.Context, request *shieldv1beta1.UpdateRo
 	}
 
 	updatedRole, err := h.roleService.Update(ctx, role.Role{
-		ID:          request.GetBody().GetId(),
-		Name:        request.GetBody().GetName(),
-		Types:       request.GetBody().GetTypes(),
-		NamespaceID: request.GetBody().GetNamespaceId(),
+		ID:          request.GetId(),
+		Name:        request.GetBody().Name,
+		Types:       request.GetBody().Types,
+		NamespaceID: request.GetBody().NamespaceId,
 		Metadata:    metaDataMap,
 	})
 	if err != nil {

--- a/internal/api/v1beta1/role.go
+++ b/internal/api/v1beta1/role.go
@@ -126,7 +126,7 @@ func (h Handler) UpdateRole(ctx context.Context, request *shieldv1beta1.UpdateRo
 		logger.Error(err.Error())
 		switch {
 		case errors.Is(err, role.ErrNotExist):
-			return nil, grpcProjectNotFoundErr
+			return nil, grpcRoleNotFoundErr
 		case errors.Is(err, role.ErrConflict):
 			return nil, grpcConflictError
 		default:

--- a/internal/store/postgres/group_repository_test.go
+++ b/internal/store/postgres/group_repository_test.go
@@ -789,6 +789,17 @@ func (s *GroupRepositoryTestSuite) TestListUserGroups() {
 			},
 		},
 		{
+			Description: "should not return error if role id is empty",
+			UserID:      s.users[0].ID,
+			ExpectedGroups: []group.Group{
+				{
+					Name:           "group1",
+					Slug:           "group-1",
+					OrganizationID: s.orgs[0].ID,
+				},
+			},
+		},
+		{
 			Description: "should get empty groups if there is none",
 			UserID:      s.users[1].ID,
 			RoleID:      role.DefinitionTeamMember.ID,
@@ -796,11 +807,6 @@ func (s *GroupRepositoryTestSuite) TestListUserGroups() {
 		{
 			Description: "should get error if user id is empty",
 			RoleID:      role.DefinitionTeamMember.ID,
-			ErrString:   group.ErrInvalidID.Error(),
-		},
-		{
-			Description: "should get error if group id is empty",
-			UserID:      s.users[0].ID,
 			ErrString:   group.ErrInvalidID.Error(),
 		},
 	}


### PR DESCRIPTION
- `ListUserGroups` should not make `roleId` mandatory
- `Create` and `Update` role service should return error if any
-  `Create` and `Update` group handler should pass both `Organization` and `OrganizationID`
- `UpdateRole` and `UpdateNamespace` ID should be immutable
- Wrong placement of switch case in `UpdatePolicy` handler