### PR TITLE
feat: streamline attribute extraction in middleware and hooks

### DIFF
--- a/internal/proxy/hook/authz/authz.go
+++ b/internal/proxy/hook/authz/authz.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/mitchellh/mapstructure"
 
@@ -12,10 +11,7 @@ import (
 	"github.com/odpf/shield/core/namespace"
 	"github.com/odpf/shield/core/project"
 	"github.com/odpf/shield/core/resource"
-	"github.com/odpf/shield/core/user"
 	"github.com/odpf/shield/internal/proxy/hook"
-	"github.com/odpf/shield/internal/proxy/middleware"
-	"github.com/odpf/shield/pkg/body_extractor"
 )
 
 type ResourceService interface {
@@ -33,9 +29,6 @@ type Authz struct {
 
 	projectService ProjectService
 
-	// TODO need to figure out what best to pass this
-	identityProxyHeaderKey string
-
 	resourceService ResourceService
 }
 
@@ -43,14 +36,13 @@ type ProjectService interface {
 	Get(ctx context.Context, id string) (project.Project, error)
 }
 
-func New(log log.Logger, next, escape hook.Service, identityProxyHeaderKey string, resourceService ResourceService, projectService ProjectService) Authz {
+func New(log log.Logger, next, escape hook.Service, resourceService ResourceService, projectService ProjectService) Authz {
 	return Authz{
-		log:                    log,
-		next:                   next,
-		escape:                 escape,
-		identityProxyHeaderKey: identityProxyHeaderKey,
-		resourceService:        resourceService,
-		projectService:         projectService,
+		log:             log,
+		next:            next,
+		escape:          escape,
+		resourceService: resourceService,
+		projectService:  projectService,
 	}
 }
 
@@ -71,8 +63,10 @@ func (a Authz) ServeHook(res *http.Response, err error) (*http.Response, error) 
 		return a.escape.ServeHook(res, err)
 	}
 
-	ruleFromRequest, ok := hook.ExtractRule(res.Request)
-	if !ok {
+	attributes := res.Request.Context().Value("requestAttributes").(map[string]any)
+	ns := attributes["namespace"]
+
+	if ns == nil {
 		return a.next.ServeHook(res, nil)
 	}
 
@@ -86,104 +80,8 @@ func (a Authz) ServeHook(res *http.Response, err error) (*http.Response, error) 
 		return a.next.ServeHook(res, nil)
 	}
 
-	if ruleFromRequest.Backend.Namespace == "" {
+	if ns == "" {
 		return a.next.ServeHook(res, fmt.Errorf("namespace variable not defined in rules"))
-	}
-
-	attributes := map[string]interface{}{}
-	attributes["namespace"] = ruleFromRequest.Backend.Namespace
-
-	identityProxyHeaderValue := res.Request.Header.Get(a.identityProxyHeaderKey)
-	attributes["user"] = identityProxyHeaderValue
-	res.Request = res.Request.WithContext(user.SetContextWithEmail(res.Request.Context(), identityProxyHeaderValue))
-
-	for id, attr := range config.Attributes {
-		bdy, _ := middleware.ExtractRequestBody(res.Request)
-		bodySource := &res.Body
-		if attr.Source == string(hook.SourceRequest) {
-			bodySource = &bdy
-		}
-
-		headerSource := &res.Header
-		if attr.Source == string(hook.SourceRequest) {
-			headerSource = &res.Request.Header
-		}
-
-		switch attr.Type {
-		case hook.AttributeTypeGRPCPayload:
-			if !strings.HasPrefix(res.Header.Get("Content-Type"), "application/grpc") {
-				a.log.Error("middleware: not a grpc request", "attr", attr)
-				return a.escape.ServeHook(res, fmt.Errorf("invalid header for http request: %s", res.Header.Get("Content-Type")))
-			}
-
-			payloadField, err := body_extractor.GRPCPayloadHandler{}.Extract(bodySource, attr.Index)
-			if err != nil {
-				a.log.Error("middleware: failed to parse grpc payload", "err", err)
-				return a.escape.ServeHook(res, fmt.Errorf("unable to parse grpc payload"))
-			}
-			attributes[id] = payloadField
-
-			a.log.Info("middleware: extracted", "field", payloadField, "attr", attr)
-		case hook.AttributeTypeJSONPayload:
-			if attr.Key == "" {
-				a.log.Error("middleware: payload key field empty")
-				return a.escape.ServeHook(res, fmt.Errorf("payload key field empty"))
-			}
-
-			payloadField, err := body_extractor.JSONPayloadHandler{}.Extract(bodySource, attr.Key)
-			if err != nil {
-				a.log.Error("middleware: failed to parse json payload", "err", err)
-				return a.escape.ServeHook(res, fmt.Errorf("failed to parse json payload"))
-			}
-			attributes[id] = payloadField
-
-			a.log.Info("middleware: extracted", "field", payloadField, "attr", attr)
-		case hook.AttributeTypeHeader:
-			if attr.Key == "" {
-				a.log.Error("middleware: header key field empty", "err", err)
-				return a.escape.ServeHook(res, fmt.Errorf("failed to parse json payload"))
-			}
-			headerAttr := headerSource.Get(attr.Key)
-			if headerAttr == "" {
-				a.log.Error(fmt.Sprintf("middleware: header %s is empty", attr.Key))
-				return a.escape.ServeHook(res, fmt.Errorf("failed to parse json payload"))
-			}
-
-			attributes[id] = headerAttr
-			a.log.Info("middleware: extracted", "field", headerAttr, "attr", attr)
-
-		case hook.AttributeTypeQuery:
-			if attr.Key == "" {
-				a.log.Error("middleware: query key field empty")
-				return a.escape.ServeHook(res, fmt.Errorf("failed to parse json payload"))
-			}
-			queryAttr := res.Request.URL.Query().Get(attr.Key)
-			if queryAttr == "" {
-				a.log.Error(fmt.Sprintf("middleware: query %s is empty", attr.Key))
-				return a.escape.ServeHook(res, fmt.Errorf("failed to parse json payload"))
-			}
-
-			attributes[id] = queryAttr
-			a.log.Info("middleware: extracted", "field", queryAttr, "attr", attr)
-
-		case hook.AttributeTypeConstant:
-			if attr.Value == "" {
-				a.log.Error("middleware: constant value empty")
-				return a.escape.ServeHook(res, fmt.Errorf("failed to parse json payload"))
-			}
-
-			attributes[id] = attr.Value
-			a.log.Info("middleware: extracted", "constant_key", res, "attr", attributes[id])
-
-		default:
-			a.log.Error("middleware: unknown attribute type", "attr", attr)
-			return a.escape.ServeHook(res, fmt.Errorf("unknown attribute type: %v", attr))
-		}
-	}
-
-	paramMap, _ := middleware.ExtractPathParams(res.Request)
-	for key, value := range paramMap {
-		attributes[key] = value
 	}
 
 	resources, err := a.createResources(res.Request.Context(), attributes)

--- a/internal/proxy/hook/authz/authz.go
+++ b/internal/proxy/hook/authz/authz.go
@@ -3,6 +3,7 @@ package authz
 import (
 	"context"
 	"fmt"
+	attributes2 "github.com/odpf/shield/internal/proxy/middleware/attributes"
 	"net/http"
 
 	"github.com/mitchellh/mapstructure"
@@ -63,7 +64,10 @@ func (a Authz) ServeHook(res *http.Response, err error) (*http.Response, error) 
 		return a.escape.ServeHook(res, err)
 	}
 
-	attributes := res.Request.Context().Value("requestAttributes").(map[string]any)
+	attributes, ok := attributes2.GetAttributesFromContext(res.Request.Context())
+	if !ok {
+		return a.escape.ServeHook(res, fmt.Errorf("unable to fetch permission attributes from context"))
+	}
 	ns := attributes["namespace"]
 
 	if ns == nil {

--- a/internal/proxy/hook/authz/authz.go
+++ b/internal/proxy/hook/authz/authz.go
@@ -12,7 +12,7 @@ import (
 	"github.com/odpf/shield/core/project"
 	"github.com/odpf/shield/core/resource"
 	"github.com/odpf/shield/internal/proxy/hook"
-	attributes2 "github.com/odpf/shield/internal/proxy/middleware/attributes"
+	"github.com/odpf/shield/internal/proxy/middleware/attributes"
 )
 
 type ResourceService interface {
@@ -64,11 +64,11 @@ func (a Authz) ServeHook(res *http.Response, err error) (*http.Response, error) 
 		return a.escape.ServeHook(res, err)
 	}
 
-	attributes, ok := attributes2.GetAttributesFromContext(res.Request.Context())
+	attrs, ok := attributes.GetAttributesFromContext(res.Request.Context())
 	if !ok {
 		return a.escape.ServeHook(res, fmt.Errorf("unable to fetch permission attributes from context"))
 	}
-	ns := attributes["namespace"]
+	ns := attrs["namespace"]
 
 	if ns == nil {
 		return a.next.ServeHook(res, nil)
@@ -88,7 +88,7 @@ func (a Authz) ServeHook(res *http.Response, err error) (*http.Response, error) 
 		return a.next.ServeHook(res, fmt.Errorf("namespace variable not defined in rules"))
 	}
 
-	resources, err := a.createResources(res.Request.Context(), attributes)
+	resources, err := a.createResources(res.Request.Context(), attrs)
 	if err != nil {
 		a.log.Error(err.Error())
 		return a.escape.ServeHook(res, fmt.Errorf(err.Error()))

--- a/internal/proxy/hook/authz/authz.go
+++ b/internal/proxy/hook/authz/authz.go
@@ -61,6 +61,11 @@ func (a Authz) ServeHook(res *http.Response, err error) (*http.Response, error) 
 		return a.escape.ServeHook(res, err)
 	}
 
+	hookSpec, ok := hook.ExtractHook(res.Request, a.Info().Name)
+	if !ok {
+		return a.next.ServeHook(res, nil)
+	}
+
 	attrs, ok := attributes.GetAttributesFromContext(res.Request.Context())
 	if !ok {
 		return a.escape.ServeHook(res, fmt.Errorf("unable to fetch permission attributes from context"))
@@ -68,11 +73,6 @@ func (a Authz) ServeHook(res *http.Response, err error) (*http.Response, error) 
 	ns := attrs["namespace"]
 
 	if ns == nil {
-		return a.next.ServeHook(res, nil)
-	}
-
-	hookSpec, ok := hook.ExtractHook(res.Request, a.Info().Name)
-	if !ok {
 		return a.next.ServeHook(res, nil)
 	}
 

--- a/internal/proxy/hook/authz/authz.go
+++ b/internal/proxy/hook/authz/authz.go
@@ -3,7 +3,6 @@ package authz
 import (
 	"context"
 	"fmt"
-	attributes2 "github.com/odpf/shield/internal/proxy/middleware/attributes"
 	"net/http"
 
 	"github.com/mitchellh/mapstructure"
@@ -13,6 +12,7 @@ import (
 	"github.com/odpf/shield/core/project"
 	"github.com/odpf/shield/core/resource"
 	"github.com/odpf/shield/internal/proxy/hook"
+	attributes2 "github.com/odpf/shield/internal/proxy/middleware/attributes"
 )
 
 type ResourceService interface {

--- a/internal/proxy/hook/authz/authz_test.go
+++ b/internal/proxy/hook/authz/authz_test.go
@@ -1,15 +1,11 @@
 package authz
 
 import (
-	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/odpf/shield/core/organization"
-	"github.com/odpf/shield/core/project"
 	"github.com/odpf/shield/core/resource"
 )
 
@@ -17,56 +13,9 @@ var testPermissionAttributesMap = map[string]any{
 	"project":       "ab657ae7-8c9e-45eb-9862-dd9ceb6d5c71",
 	"team":          "team1",
 	"resource":      []string{"resc1", "resc2"},
+	"organization":  "org1",
 	"namespace":     "ns1",
 	"resource_type": "kind",
-}
-
-var testProjectMap = map[string]project.Project{
-	"ab657ae7-8c9e-45eb-9862-dd9ceb6d5c71": {
-		ID:   "ab657ae7-8c9e-45eb-9862-dd9ceb6d5c71",
-		Name: "Prj 1",
-		Slug: "prj-1",
-		Metadata: map[string]any{
-			"email": "org1@org1.com",
-		},
-		Organization: organization.Organization{
-			ID:   "org1",
-			Name: "Org 1",
-			Slug: "Org Slug 1",
-		},
-		CreatedAt: time.Time{},
-		UpdatedAt: time.Time{},
-	},
-	"c7772c63-fca4-4c7c-bf93-c8f85115de4b": {
-		ID:   "c7772c63-fca4-4c7c-bf93-c8f85115de4b",
-		Name: "Prj 2",
-		Slug: "prj-2",
-		Metadata: map[string]any{
-			"email": "org1@org2.com",
-		},
-		Organization: organization.Organization{
-			ID:   "org2",
-			Name: "Org 2",
-			Slug: "Org Slug 2",
-		},
-		CreatedAt: time.Time{},
-		UpdatedAt: time.Time{},
-	},
-	"project-3-slug": {
-		ID:   "c3772d61-faa1-4d8d-fff3-c8fa5a1fdc4b",
-		Name: "Prj 3",
-		Slug: "project-3-slug",
-		Metadata: map[string]any{
-			"email": "org1@org2.com",
-		},
-		Organization: organization.Organization{
-			ID:   "org2",
-			Name: "Org 2",
-			Slug: "Org Slug 2",
-		},
-		CreatedAt: time.Time{},
-		UpdatedAt: time.Time{},
-	},
 }
 
 var expectedResources = []resource.Resource{
@@ -106,6 +55,7 @@ func TestCreateResources(t *testing.T) {
 			permissionAttributes: map[string]any{
 				"team":          "team1",
 				"resource":      []string{"resc1", "resc2"},
+				"organization":  "org1",
 				"namespace":     "ns1",
 				"resource_type": "kind",
 			},
@@ -117,6 +67,7 @@ func TestCreateResources(t *testing.T) {
 			permissionAttributes: map[string]any{
 				"project":       "ab657ae7-8c9e-45eb-9862-dd9ceb6d5c71",
 				"resource":      []string{"resc1", "resc2"},
+				"organization":  "org1",
 				"namespace":     "ns1",
 				"resource_type": "kind",
 			},
@@ -128,6 +79,7 @@ func TestCreateResources(t *testing.T) {
 			permissionAttributes: map[string]any{
 				"project":       "c7772c63-fca4-4c7c-bf93-c8f85115de4b",
 				"team":          "team1",
+				"organization":  "org2",
 				"resource":      "res1",
 				"namespace":     "ns1",
 				"resource_type": "type",
@@ -155,12 +107,4 @@ func TestCreateResources(t *testing.T) {
 			assert.EqualValues(t, tt.err, err)
 		})
 	}
-}
-
-type mockProject struct {
-	GetProjectFunc func(ctx context.Context, id string) (project.Project, error)
-}
-
-func (m mockProject) Get(ctx context.Context, id string) (project.Project, error) {
-	return m.GetProjectFunc(ctx, id)
 }

--- a/internal/proxy/hook/authz/authz_test.go
+++ b/internal/proxy/hook/authz/authz_test.go
@@ -98,56 +98,33 @@ func TestCreateResources(t *testing.T) {
 		{
 			title:                "success/should return multiple resources",
 			permissionAttributes: testPermissionAttributesMap,
-			a: Authz{
-				projectService: mockProject{
-					GetProjectFunc: func(ctx context.Context, id string) (project.Project, error) {
-						return testProjectMap[id], nil
-					}},
-			},
-			want: expectedResources,
-			err:  nil,
+			a:                    Authz{},
+			want:                 expectedResources,
+			err:                  nil,
 		}, {
 			title: "should should throw error if project is missing",
-			a: Authz{
-				projectService: mockProject{
-					GetProjectFunc: func(ctx context.Context, id string) (project.Project, error) {
-						return project.Project{}, fmt.Errorf("Project ID not found")
-					},
-				},
-			},
 			permissionAttributes: map[string]any{
 				"team":          "team1",
 				"resource":      []string{"resc1", "resc2"},
 				"namespace":     "ns1",
 				"resource_type": "kind",
 			},
+			a:    Authz{},
 			want: nil,
 			err:  fmt.Errorf("namespace, resource type, projects, resource, and team are required"),
 		}, {
 			title: "should should throw error if team is missing",
-			a: Authz{
-				projectService: mockProject{
-					GetProjectFunc: func(ctx context.Context, id string) (project.Project, error) {
-						return testProjectMap[id], nil
-					},
-				},
-			},
 			permissionAttributes: map[string]any{
 				"project":       "ab657ae7-8c9e-45eb-9862-dd9ceb6d5c71",
 				"resource":      []string{"resc1", "resc2"},
 				"namespace":     "ns1",
 				"resource_type": "kind",
 			},
+			a:    Authz{},
 			want: nil,
 			err:  fmt.Errorf("namespace, resource type, projects, resource, and team are required"),
 		}, {
 			title: "success/should return resource",
-			a: Authz{
-				projectService: mockProject{
-					GetProjectFunc: func(ctx context.Context, id string) (project.Project, error) {
-						return testProjectMap[id], nil
-					}},
-			},
 			permissionAttributes: map[string]any{
 				"project":       "c7772c63-fca4-4c7c-bf93-c8f85115de4b",
 				"team":          "team1",
@@ -155,6 +132,7 @@ func TestCreateResources(t *testing.T) {
 				"namespace":     "ns1",
 				"resource_type": "type",
 			},
+			a: Authz{},
 			want: []resource.Resource{
 				{
 					ProjectID:      "c7772c63-fca4-4c7c-bf93-c8f85115de4b",
@@ -172,7 +150,7 @@ func TestCreateResources(t *testing.T) {
 		t.Run(tt.title, func(t *testing.T) {
 			t.Parallel()
 
-			resp, err := tt.a.createResources(context.Background(), tt.permissionAttributes)
+			resp, err := tt.a.createResources(tt.permissionAttributes)
 			assert.EqualValues(t, tt.want, resp)
 			assert.EqualValues(t, tt.err, err)
 		})

--- a/internal/proxy/middleware/attributes/attributes.go
+++ b/internal/proxy/middleware/attributes/attributes.go
@@ -1,7 +1,6 @@
 package attributes
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -167,8 +166,7 @@ func (a *Attributes) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		requestAttributes[key] = value
 	}
 
-	attributesContext := context.WithValue(req.Context(), "requestAttributes", requestAttributes)
-	req = req.WithContext(attributesContext)
+	req = req.WithContext(SetContextWithAttributes(req.Context(), requestAttributes))
 
 	a.next.ServeHTTP(rw, req)
 }

--- a/internal/proxy/middleware/attributes/attributes.go
+++ b/internal/proxy/middleware/attributes/attributes.go
@@ -1,0 +1,174 @@
+package attributes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/odpf/salt/log"
+	"github.com/odpf/shield/core/user"
+	"github.com/odpf/shield/internal/proxy/middleware"
+	"github.com/odpf/shield/pkg/body_extractor"
+)
+
+type Attributes struct {
+	log                    log.Logger
+	next                   http.Handler
+	identityProxyHeaderKey string
+}
+
+type Config struct {
+	Attributes map[string]middleware.Attribute `yaml:"attributes" mapstructure:"attributes"`
+}
+
+func New(
+	log log.Logger,
+	next http.Handler,
+	identityProxyHeaderKey string,
+) *Attributes {
+	return &Attributes{
+		log:                    log,
+		next:                   next,
+		identityProxyHeaderKey: identityProxyHeaderKey,
+	}
+}
+
+func (a Attributes) Info() *middleware.MiddlewareInfo {
+	return &middleware.MiddlewareInfo{
+		Name:        "attributes",
+		Description: "Attribute Extraction",
+	}
+}
+
+func (a Attributes) notAllowed(rw http.ResponseWriter) {
+	rw.WriteHeader(http.StatusUnauthorized)
+	return
+}
+
+func (a *Attributes) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	requestAttributes := map[string]any{}
+
+	wareSpec, _ := middleware.ExtractMiddleware(req, a.Info().Name)
+
+	req = req.WithContext(user.SetContextWithEmail(req.Context(), req.Header.Get(a.identityProxyHeaderKey)))
+	requestAttributes["user"] = req.Header.Get(a.identityProxyHeaderKey)
+
+	config := Config{}
+	if err := mapstructure.Decode(wareSpec.Config, &config); err != nil {
+		a.log.Error("middleware: invalid config", "config", wareSpec.Config)
+		a.notAllowed(rw)
+		return
+	}
+
+	rule, ok := middleware.ExtractRule(req)
+	if ok {
+		requestAttributes["namespace"] = rule.Backend.Namespace
+		requestAttributes["prefix"] = rule.Backend.Prefix
+	}
+
+	for res, attr := range config.Attributes {
+		_ = res
+
+		switch attr.Type {
+		case middleware.AttributeTypeGRPCPayload:
+			// check if grpc request
+			if !strings.HasPrefix(req.Header.Get("Content-Type"), "application/grpc") {
+				a.log.Error("middleware: not a grpc request", "attr", attr)
+				a.notAllowed(rw)
+				return
+			}
+
+			// TODO: we can optimise this by parsing all field at once
+			payloadField, err := body_extractor.GRPCPayloadHandler{}.Extract(&req.Body, attr.Index)
+			if err != nil {
+				a.log.Error("middleware: failed to parse grpc payload", "err", err)
+				return
+			}
+
+			requestAttributes[res] = payloadField
+			a.log.Info("middleware: extracted", "field", payloadField, "attr", attr)
+
+		case middleware.AttributeTypeJSONPayload:
+			if attr.Key == "" {
+				a.log.Error("middleware: payload key field empty")
+				a.notAllowed(rw)
+				return
+			}
+			payloadField, err := body_extractor.JSONPayloadHandler{}.Extract(&req.Body, attr.Key)
+			if err != nil {
+				a.log.Error("middleware: failed to parse grpc payload", "err", err)
+				a.notAllowed(rw)
+				return
+			}
+
+			requestAttributes[res] = payloadField
+			a.log.Info("middleware: extracted", "field", payloadField, "attr", attr)
+
+		case middleware.AttributeTypeHeader:
+			if attr.Key == "" {
+				a.log.Error("middleware: header key field empty")
+				a.notAllowed(rw)
+				return
+			}
+			headerAttr := req.Header.Get(attr.Key)
+			if headerAttr == "" {
+				a.log.Error(fmt.Sprintf("middleware: header %s is empty", attr.Key))
+				a.notAllowed(rw)
+				return
+			}
+
+			requestAttributes[res] = headerAttr
+			a.log.Info("middleware: extracted", "field", headerAttr, "attr", attr)
+
+		case middleware.AttributeTypeQuery:
+			if attr.Key == "" {
+				a.log.Error("middleware: query key field empty")
+				a.notAllowed(rw)
+				return
+			}
+			queryAttr := req.URL.Query().Get(attr.Key)
+			if queryAttr == "" {
+				a.log.Error(fmt.Sprintf("middleware: query %s is empty", attr.Key))
+				a.notAllowed(rw)
+				return
+			}
+
+			requestAttributes[res] = queryAttr
+			a.log.Info("middleware: extracted", "field", queryAttr, "attr", attr)
+
+		case middleware.AttributeTypeConstant:
+			if attr.Value == "" {
+				a.log.Error("middleware: constant value empty")
+				a.notAllowed(rw)
+				return
+			}
+
+			requestAttributes[res] = attr.Value
+			a.log.Info("middleware: extracted", "constant_key", res, "attr", requestAttributes[res])
+
+		default:
+			a.log.Error("middleware: unknown attribute type", "attr", attr)
+			a.notAllowed(rw)
+			return
+		}
+	}
+
+	paramMap, mapExists := middleware.ExtractPathParams(req)
+	if !mapExists {
+		a.log.Error("middleware: path param map doesn't exist")
+		a.notAllowed(rw)
+		return
+	}
+
+	for key, value := range paramMap {
+		requestAttributes[key] = value
+	}
+
+	attributesContext := context.WithValue(req.Context(), "requestAttributes", requestAttributes)
+	req = req.WithContext(attributesContext)
+
+	a.next.ServeHTTP(rw, req)
+}

--- a/internal/proxy/middleware/attributes/attributes_test.go
+++ b/internal/proxy/middleware/attributes/attributes_test.go
@@ -1,0 +1,237 @@
+package attributes
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/odpf/salt/log"
+	"github.com/odpf/shield/core/rule"
+	"github.com/odpf/shield/internal/proxy/middleware"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/odpf/shield/core/organization"
+	"github.com/odpf/shield/core/project"
+)
+
+var testPermissionAttributesMap = map[string]any{
+	"project":       "85be2dfe-7b13-42aa-96f8-f040afb0bbb3",
+	"team":          "e16f46cf-6e1e-4802-967a-ea4008ee0ca3",
+	"resource":      "p-gojek-test-firehose-nb-test-11",
+	"resource_type": "firehose",
+	"user":          "nihar.b.interns@aux.gojek.com",
+	"namespace":     "odin",
+	"prefix":        "/api",
+	"organization":  "39e63abd-0fb0-4f5a-ac24-92bf83e1f920",
+}
+
+var testProjectMap = map[string]project.Project{
+	"ab657ae7-8c9e-45eb-9862-dd9ceb6d5c71": {
+		ID:   "ab657ae7-8c9e-45eb-9862-dd9ceb6d5c71",
+		Name: "Prj 1",
+		Slug: "prj-1",
+		Metadata: map[string]any{
+			"email": "org1@org1.com",
+		},
+		Organization: organization.Organization{
+			ID:   "org1",
+			Name: "Org 1",
+			Slug: "Org Slug 1",
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	},
+	"85be2dfe-7b13-42aa-96f8-f040afb0bbb3": {
+		ID:   "85be2dfe-7b13-42aa-96f8-f040afb0bbb3",
+		Name: "Prj 2",
+		Slug: "prj-2",
+		Metadata: map[string]any{
+			"email": "org1@org2.com",
+		},
+		Organization: organization.Organization{
+			ID:   "39e63abd-0fb0-4f5a-ac24-92bf83e1f920",
+			Name: "Org 2",
+			Slug: "Org Slug 2",
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	},
+	"project-3-slug": {
+		ID:   "c3772d61-faa1-4d8d-fff3-c8fa5a1fdc4b",
+		Name: "Prj 3",
+		Slug: "project-3-slug",
+		Metadata: map[string]any{
+			"email": "org1@org2.com",
+		},
+		Organization: organization.Organization{
+			ID:   "org2",
+			Name: "Org 2",
+			Slug: "Org Slug 2",
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	},
+}
+
+func TestExtractMiddleware(t *testing.T) {
+	t.Parallel()
+
+	odinRule := rule.Rule{
+		Frontend: rule.Frontend{
+			URL:    "/api/firehoses",
+			Method: "POST",
+		},
+		Backend: rule.Backend{
+			URL:       "http://localhost:3000",
+			Namespace: "odin",
+			Prefix:    "/api",
+		},
+		Middlewares: rule.MiddlewareSpecs{
+			rule.MiddlewareSpec{
+				Name: "attributes",
+				Config: map[string]interface{}{
+					"attributes": map[string]any{
+						"project": map[string]any{
+							"key":    "X-Shield-Project",
+							"source": "request",
+							"type":   "header",
+						},
+						"resource": map[string]any{
+							"key":    "name",
+							"source": "request",
+							"type":   "json_payload",
+						},
+						"resource_type": map[string]any{
+							"type":  "constant",
+							"value": "firehose",
+						},
+						"team": map[string]any{
+							"key":    "X-Shield-Group",
+							"source": "request",
+							"type":   "header",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	postBody, _ := json.Marshal(map[string]string{
+		"name": "p-gojek-test-firehose-nb-test-11",
+	})
+	responseBody := bytes.NewBuffer(postBody)
+
+	table := []struct {
+		title                string
+		permissionAttributes map[string]any
+		rw                   http.ResponseWriter
+		req                  *http.Request
+		name                 string
+		a                    Attributes
+		want                 map[string]any
+		ok                   bool
+	}{
+		{
+			title:                "success",
+			permissionAttributes: testPermissionAttributesMap,
+			rw:                   nil,
+			req: &http.Request{
+				Method: "POST",
+				Header: map[string][]string{
+					"X-Shield-Project": {"85be2dfe-7b13-42aa-96f8-f040afb0bbb3"},
+					"X-Auth-Email":     {"nihar.b.interns@aux.gojek.com"},
+					"X-Shield-Group":   {"e16f46cf-6e1e-4802-967a-ea4008ee0ca3"},
+				},
+				Body: ioutil.NopCloser(responseBody),
+			},
+			a: Attributes{
+				log:                    log.NewNoop(),
+				next:                   &mockNextHandler{},
+				identityProxyHeaderKey: "X-Auth-Email",
+				projectService: mockProject{
+					GetProjectFunc: func(ctx context.Context, id string) (project.Project, error) {
+						return testProjectMap[id], nil
+					},
+				},
+			},
+			want: testPermissionAttributesMap,
+		},
+		{
+			title:                "error in getting organization",
+			permissionAttributes: testPermissionAttributesMap,
+			rw:                   nil,
+			req: &http.Request{
+				Method: "POST",
+				Header: map[string][]string{
+					"X-Shield-Project": {"a5ae3dfe-7b13-42aa-96f8-f040afb0bbb3"},
+					"X-Auth-Email":     {"nihar.b.interns@aux.gojek.com"},
+					"X-Shield-Group":   {"e16f46cf-6e1e-4802-967a-ea4008ee0ca3"},
+				},
+				Body: ioutil.NopCloser(responseBody),
+			},
+			a: Attributes{
+				log:                    log.NewNoop(),
+				next:                   &mockNextHandler{},
+				identityProxyHeaderKey: "X-Auth-Email",
+				projectService: mockProject{
+					GetProjectFunc: func(ctx context.Context, id string) (project.Project, error) {
+						return project.Project{}, fmt.Errorf("Project not found")
+					},
+				},
+			},
+			want: map[string]any{
+				"project":       "a5ae3dfe-7b13-42aa-96f8-f040afb0bbb3",
+				"team":          "e16f46cf-6e1e-4802-967a-ea4008ee0ca3",
+				"resource":      "p-gojek-test-firehose-nb-test-11",
+				"resource_type": "firehose",
+				"user":          "nihar.b.interns@aux.gojek.com",
+				"namespace":     "odin",
+				"prefix":        "/api",
+				"organization":  "",
+			},
+			ok: true,
+		},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.title, func(t *testing.T) {
+			t.Parallel()
+
+			middleware.EnrichRule(tt.req, &odinRule)
+			middleware.EnrichPathParams(tt.req, map[string]string{})
+			w := httptest.NewRecorder()
+			tt.a.ServeHTTP(w, tt.req)
+			ctx := tt.a.next.(*mockNextHandler).getContext()
+			attrMap, ok := GetAttributesFromContext(ctx)
+			assert.EqualValues(t, tt.ok, ok)
+			assert.EqualValues(t, tt.want, attrMap)
+		})
+	}
+}
+
+type mockNextHandler struct {
+	ctx context.Context
+}
+
+func (m *mockNextHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	m.ctx = req.Context()
+	return
+}
+
+func (m *mockNextHandler) getContext() context.Context {
+	return m.ctx
+}
+
+type mockProject struct {
+	GetProjectFunc func(ctx context.Context, id string) (project.Project, error)
+}
+
+func (m mockProject) Get(ctx context.Context, id string) (project.Project, error) {
+	return m.GetProjectFunc(ctx, id)
+}

--- a/internal/proxy/middleware/attributes/context.go
+++ b/internal/proxy/middleware/attributes/context.go
@@ -1,0 +1,14 @@
+package attributes
+
+import "context"
+
+type contextAttributesMap struct{}
+
+func SetContextWithAttributes(ctx context.Context, requestAttributes map[string]any) context.Context {
+	return context.WithValue(ctx, contextAttributesMap{}, requestAttributes)
+}
+
+func GetAttributesFromContext(ctx context.Context) (map[string]any, bool) {
+	requestAttributes, ok := ctx.Value(contextAttributesMap{}).(map[string]any)
+	return requestAttributes, ok
+}

--- a/internal/proxy/middleware/authz/authz.go
+++ b/internal/proxy/middleware/authz/authz.go
@@ -3,7 +3,6 @@ package authz
 import (
 	"context"
 	"fmt"
-	"github.com/odpf/shield/internal/proxy/middleware/attributes"
 	"net/http"
 
 	"github.com/mitchellh/mapstructure"
@@ -14,6 +13,7 @@ import (
 	"github.com/odpf/shield/core/resource"
 	"github.com/odpf/shield/core/user"
 	"github.com/odpf/shield/internal/proxy/middleware"
+	"github.com/odpf/shield/internal/proxy/middleware/attributes"
 )
 
 type ResourceService interface {

--- a/internal/proxy/middleware/authz/authz.go
+++ b/internal/proxy/middleware/authz/authz.go
@@ -3,6 +3,7 @@ package authz
 import (
 	"context"
 	"fmt"
+	"github.com/odpf/shield/internal/proxy/middleware/attributes"
 	"net/http"
 
 	"github.com/mitchellh/mapstructure"
@@ -68,7 +69,12 @@ func (c *Authz) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	req.Header.Set(c.userIDHeaderKey, usr.ID)
 
-	permissionAttributes := req.Context().Value("requestAttributes").(map[string]any)
+	permissionAttributes, ok := attributes.GetAttributesFromContext(req.Context())
+	if !ok {
+		c.log.Error("unable to fetch permission attributes from context")
+		c.notAllowed(rw)
+		return
+	}
 	ns := permissionAttributes["namespace"]
 
 	if ns == nil {

--- a/internal/proxy/middleware/prefix/prefix.go
+++ b/internal/proxy/middleware/prefix/prefix.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/odpf/salt/log"
-	"github.com/odpf/shield/internal/proxy/middleware"
 )
 
 type Ware struct {
@@ -21,12 +20,13 @@ func New(log log.Logger, next http.Handler) *Ware {
 }
 
 func (w *Ware) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	rules, ok := middleware.ExtractRule(req)
-	if !ok {
+	prefixInterface := req.Context().Value("prefix")
+	if prefixInterface == nil {
 		w.next.ServeHTTP(rw, req)
 		return
 	}
-	prefixStr := rules.Backend.Prefix
+
+	prefixStr := prefixInterface.(string)
 	req.URL.Path = w.getPrefixStripped(req.URL.Path, prefixStr)
 	if req.URL.RawPath != "" {
 		req.URL.RawPath = w.getPrefixStripped(req.URL.RawPath, prefixStr)

--- a/internal/proxy/middleware/prefix/prefix.go
+++ b/internal/proxy/middleware/prefix/prefix.go
@@ -1,6 +1,7 @@
 package prefix
 
 import (
+	"github.com/odpf/shield/internal/proxy/middleware/attributes"
 	"net/http"
 	"strings"
 
@@ -20,7 +21,8 @@ func New(log log.Logger, next http.Handler) *Ware {
 }
 
 func (w *Ware) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	prefixInterface := req.Context().Value("prefix")
+	permissionAttributes, _ := attributes.GetAttributesFromContext(req.Context())
+	prefixInterface := permissionAttributes["prefix"]
 	if prefixInterface == nil {
 		w.next.ServeHTTP(rw, req)
 		return

--- a/internal/proxy/middleware/prefix/prefix.go
+++ b/internal/proxy/middleware/prefix/prefix.go
@@ -1,11 +1,11 @@
 package prefix
 
 import (
-	"github.com/odpf/shield/internal/proxy/middleware/attributes"
 	"net/http"
 	"strings"
 
 	"github.com/odpf/salt/log"
+	"github.com/odpf/shield/internal/proxy/middleware/attributes"
 )
 
 type Ware struct {

--- a/test/integration_test/grpc_test.go
+++ b/test/integration_test/grpc_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/odpf/shield/core/project"
 	"github.com/odpf/shield/core/rule"
 	"github.com/odpf/shield/internal/proxy"
 	"github.com/odpf/shield/internal/proxy/hook"
@@ -50,7 +51,8 @@ func TestGRPCProxyHelloWorld(t *testing.T) {
 	}
 	defer ruleRepo.Close()
 	ruleService := rule.NewService(ruleRepo)
-	pipeline := buildPipeline(log.NewNoop(), h2cProxy, ruleService)
+	projectService := project.Service{}
+	pipeline := buildPipeline(log.NewNoop(), h2cProxy, ruleService, &projectService)
 
 	proxyURL := fmt.Sprintf(":%d", grpcProxyPort)
 	mux := http.NewServeMux()
@@ -149,7 +151,8 @@ func BenchmarkGRPCProxyHelloWorld(b *testing.B) {
 	}
 	defer ruleRepo.Close()
 	ruleService := rule.NewService(ruleRepo)
-	pipeline := buildPipeline(log.NewNoop(), h2cProxy, ruleService)
+	projectService := project.Service{}
+	pipeline := buildPipeline(log.NewNoop(), h2cProxy, ruleService, &projectService)
 
 	proxyURL := fmt.Sprintf(":%d", grpcProxyPort)
 	mux := http.NewServeMux()

--- a/test/integration_test/rest_test.go
+++ b/test/integration_test/rest_test.go
@@ -296,14 +296,14 @@ func buildPipeline(logger log.Logger, proxy http.Handler, ruleService *rule.Serv
 	prefixWare := prefix.New(logger, proxy)
 	//casbinAuthz := authz.New(logger, "", server.Deps{}, prefixWare)
 	basicAuthn := basic_auth.New(logger, prefixWare)
-	attributeExtractor := attributes.New(logger, basicAuthn, "")
+	attributeExtractor := attributes.New(logger, basicAuthn, "X-Auth-Email", &project.Service{})
 	matchWare := rulematch.New(logger, attributeExtractor, rulematch.NewRouteMatcher(ruleService))
 	return matchWare
 }
 
 func hookPipeline(log log.Logger) hook.Service {
 	rootHook := hook.New()
-	return authz_hook.New(log, rootHook, rootHook, &resource.Service{}, &project.Service{})
+	return authz_hook.New(log, rootHook, rootHook, &resource.Service{})
 }
 
 func startTestHTTPServer(port, statusCode int, content, proto string) (ts *httptest.Server) {

--- a/test/integration_test/rest_test.go
+++ b/test/integration_test/rest_test.go
@@ -301,7 +301,7 @@ func buildPipeline(logger log.Logger, proxy http.Handler, ruleService *rule.Serv
 
 func hookPipeline(log log.Logger) hook.Service {
 	rootHook := hook.New()
-	return authz_hook.New(log, rootHook, rootHook, "", &resource.Service{}, &project.Service{})
+	return authz_hook.New(log, rootHook, rootHook, &resource.Service{}, &project.Service{})
 }
 
 func startTestHTTPServer(port, statusCode int, content, proto string) (ts *httptest.Server) {

--- a/test/integration_test/rest_test.go
+++ b/test/integration_test/rest_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/odpf/shield/internal/proxy"
 	"github.com/odpf/shield/internal/proxy/hook"
 	authz_hook "github.com/odpf/shield/internal/proxy/hook/authz"
+	"github.com/odpf/shield/internal/proxy/middleware/attributes"
 	basic_auth "github.com/odpf/shield/internal/proxy/middleware/basic_auth"
 	"github.com/odpf/shield/internal/proxy/middleware/prefix"
 	"github.com/odpf/shield/internal/proxy/middleware/rulematch"
@@ -295,7 +296,8 @@ func buildPipeline(logger log.Logger, proxy http.Handler, ruleService *rule.Serv
 	prefixWare := prefix.New(logger, proxy)
 	//casbinAuthz := authz.New(logger, "", server.Deps{}, prefixWare)
 	basicAuthn := basic_auth.New(logger, prefixWare)
-	matchWare := rulematch.New(logger, basicAuthn, rulematch.NewRouteMatcher(ruleService))
+	attributeExtractor := attributes.New(logger, basicAuthn, "")
+	matchWare := rulematch.New(logger, attributeExtractor, rulematch.NewRouteMatcher(ruleService))
 	return matchWare
 }
 


### PR DESCRIPTION
Created a new layer for attribute extraction right after `rulematch`.
It pushes all the attributes into the context for the use of middleware and hook.

Current flow: Request -> [Middleware starts] Rule Matching -> Basic Auth -> Authz -> Prefix -> Backend -> [Hook starts] Authz -> Response

Modified flow with this PR: Request -> [Middleware starts] Rule Matching -> **_Attribute Extraction_** -> Basic Auth -> Authz -> Prefix -> Backend -> [Hook starts] Authz -> Response
Closes #157 