### PR TITLE
fix: don't fail for missing configuration file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,9 +55,7 @@ func Load(serverConfigfileFromFlag string) (*Shield, error) {
 
 	l := config.NewLoader(options...)
 	if err := l.Load(conf); err != nil {
-		if errors.As(err, &config.ConfigFileNotFoundError{}) {
-			return nil, errors.New("config file not found")
-		} else {
+		if !errors.As(err, &config.ConfigFileNotFoundError{}) {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Shield already supports taking configs from env but the cli fails if it didn't find a config file locally. It should either add validation to check if configs are present or continue the execution.